### PR TITLE
[Refactor] post,comment securityConfig url 추가 및 수정

### DIFF
--- a/src/main/java/com/tools/seoultech/timoproject/auth/config/SecurityConfig.java
+++ b/src/main/java/com/tools/seoultech/timoproject/auth/config/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.tools.seoultech.timoproject.member.config;
+package com.tools.seoultech.timoproject.auth.config;
 
 import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import com.tools.seoultech.timoproject.auth.jwt.HeaderTokenExtractor;

--- a/src/main/java/com/tools/seoultech/timoproject/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/tools/seoultech/timoproject/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -37,7 +37,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             new AntPathRequestMatcher("/api/v1/auth/naver"),
             new AntPathRequestMatcher("/api/v1/auth/refresh"),
             new AntPathRequestMatcher("/api/v1/auth/test"),
-            new AntPathRequestMatcher("/naver/callback")
+            new AntPathRequestMatcher("/naver/callback"),
+            new AntPathRequestMatcher("/api/v1/posts/public/**"),       // GET 요청 허용
+            new AntPathRequestMatcher("/api/v1/comments/public/**")      // GET 요청 허용
     );
 
     @Override

--- a/src/main/java/com/tools/seoultech/timoproject/member/config/SecurityConfig.java
+++ b/src/main/java/com/tools/seoultech/timoproject/member/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.tools.seoultech.timoproject.member.config;
 
+import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import com.tools.seoultech.timoproject.auth.jwt.HeaderTokenExtractor;
 import com.tools.seoultech.timoproject.auth.jwt.JwtResolver;
 import com.tools.seoultech.timoproject.auth.jwt.filter.JwtAccessDeniedHandler;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
@@ -74,7 +76,10 @@ public class SecurityConfig {
 
                 // ⑥ URL 권한 설정
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/", "/oauth2/**", "/login/**", "/api/v1/auth/**", "/naver/callback").permitAll()
+                        .requestMatchers("/", "/oauth2/**", "/login/**", "/api/v1/auth/**","/naver/callback").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/posts/public/**", "/api/v1/comments/public/**").permitAll()
+                        // post나 comment 작성, 수정, 삭제는 인증 필요. 메서드 별로 구별해야 돼
+                        .requestMatchers("/api/v1/posts/**", "/api/v1/comments/**").authenticated()
                         .requestMatchers("/api/v1/**", "api/v1/members/**").authenticated()
                         .requestMatchers(
                                 "/bower_components/**",

--- a/src/main/java/com/tools/seoultech/timoproject/post/controller/CommentApiController.java
+++ b/src/main/java/com/tools/seoultech/timoproject/post/controller/CommentApiController.java
@@ -18,7 +18,7 @@ import java.util.List;
 public class CommentApiController {
     private final CommentService commentService;
 
-    @GetMapping("/{commentId}")
+    @GetMapping("/public/{commentId}")
     public ResponseEntity<APIDataResponse<CommentDTO.Response>> readComment (
             @PathVariable Long commentId
     ) {
@@ -27,7 +27,7 @@ public class CommentApiController {
                 .status(HttpStatus.OK)
                 .body(APIDataResponse.of(readDto));
     }
-    @GetMapping
+    @GetMapping("/public")
     public ResponseEntity<APIDataResponse<List<CommentDTO.Response>>> readAllComments() {
         List<CommentDTO.Response> readDtoList = commentService.readAll();
         return ResponseEntity

--- a/src/main/java/com/tools/seoultech/timoproject/post/controller/PostApiController.java
+++ b/src/main/java/com/tools/seoultech/timoproject/post/controller/PostApiController.java
@@ -1,5 +1,6 @@
 package com.tools.seoultech.timoproject.post.controller;
 
+import com.tools.seoultech.timoproject.global.annotation.CurrentMemberId;
 import com.tools.seoultech.timoproject.post.domain.dto.PostDTO;
 import com.tools.seoultech.timoproject.post.domain.entity.Post;
 import com.tools.seoultech.timoproject.post.service.PostServiceImpl;
@@ -12,57 +13,57 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/posts")
 @RequiredArgsConstructor
 public class PostApiController {
     private final PostServiceImpl postService;
 
-    @GetMapping("/posts/{postId}")
+    @GetMapping("/public/{postId}")
     public ResponseEntity<APIDataResponse<PostDTO.Response>> readPost(@PathVariable("postId") Long postId) {
         PostDTO.Response postDto = postService.read(postId);
         return ResponseEntity.status(HttpStatus.OK).body(APIDataResponse.of(postDto));
     }
 
-    @GetMapping("/posts/member")
+    @GetMapping("/member")
     public ResponseEntity<APIDataResponse<List<PostDTO.Response>>> readPostsByMember(
-            @RequestParam("memberId") Long memberId
+            @CurrentMemberId Long memberId
     ) {
         List<PostDTO.Response> postList =  postService.readByMember(memberId);
         return ResponseEntity.status(HttpStatus.OK).body(APIDataResponse.of(postList));
     }
-    @GetMapping("/posts")
+    @GetMapping("/public")
     public ResponseEntity<APIDataResponse<List<PostDTO.Response>>> readAllPosts() {
         List<PostDTO.Response> postDtoList = postService.readAll();
         return ResponseEntity.status(HttpStatus.OK).body(APIDataResponse.of(postDtoList));
     }
-    @PostMapping("/posts")
+    @PostMapping("")
     public ResponseEntity<APIDataResponse<PostDTO.Response>> createPost(@RequestBody PostDTO.Request postDto) {
         System.err.println(postDto.toString());
         PostDTO.Response dto = postService.create(postDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(APIDataResponse.of(dto));
     }
-    @PutMapping("/posts/{postId}")
+    @PutMapping("/{postId}")
     public ResponseEntity<APIDataResponse<PostDTO.Response>> updatePost(
             @PathVariable Long postId, @RequestBody PostDTO.Request postDto
     ) {
         PostDTO.Response dto = postService.update(postId, postDto);
         return ResponseEntity.status(HttpStatus.OK).body(APIDataResponse.of(dto));
     }
-    @DeleteMapping("/posts/{postId}")
+    @DeleteMapping("/{postId}")
     public ResponseEntity<APIDataResponse> deletePost(@PathVariable("postId") Long postId) {
         postService.delete(postId);
         return ResponseEntity.status(HttpStatus.OK).body(APIDataResponse.empty());
     }
-    @GetMapping("/posts/{postId}/likeCount/increase")
+    @GetMapping("/{postId}/likeCount/increase")
     public ResponseEntity<APIDataResponse> increaseLikeCount(
-            @PathVariable("postId") Long postId, @RequestParam Long memberId
+            @PathVariable("postId") Long postId, @CurrentMemberId Long memberId
     ) {
         PostDTO.Response responseDto = postService.increaseLikeCount(postId, memberId);
         return ResponseEntity.status(HttpStatus.OK).body(APIDataResponse.of(responseDto));
     }
-    @GetMapping("/posts/{postId}/likeCount/decrease")
+    @GetMapping("/{postId}/likeCount/decrease")
     public ResponseEntity<APIDataResponse> decreaseLikeCount(
-            @PathVariable("postId") Long postId, @RequestParam Long memberId
+            @PathVariable("postId") Long postId, @CurrentMemberId Long memberId
     ) {
         PostDTO.Response responseDto = postService.decreaseLikeCount(postId, memberId);
         return ResponseEntity.status(HttpStatus.OK).body(APIDataResponse.of(responseDto));


### PR DESCRIPTION
## #️⃣연관된 이슈

#53 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 공용 API url 수정 (/posts/public, /comments/public)(예를 들어, post 조회나 comment 조회 기능은 로그인 유무 상관없이 가능하니까)
- 멤버 아이디 받아오는 부분은 Authorization 토큰으로 받아오기
    - @CurrentMemberId 어노테이션 사용하면 됨
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- domain 따로 분리하기
    - comment, like
- post → [POST] create 할때 @CurrentMemberId 이용하기
- comments 내가 쓴 댓글 조회 필요
- comments update 포스트맨에 작성하기
- comments 전체 댓글 조회 → 해당 게시글 전체 조회