### PR TITLE
Feat/#63 match service algorithm

### DIFF
--- a/src/main/java/com/tools/seoultech/timoproject/match/controller/MatchController.java
+++ b/src/main/java/com/tools/seoultech/timoproject/match/controller/MatchController.java
@@ -34,6 +34,13 @@ public class MatchController {
         }
     }
 
+    /** 테스트 데이터 Redis 삽입 */
+    @PostMapping("/queue/test")
+    public APIDataResponse<?> saveTestDataToRedis() {
+        matchingService.saveTestDataToRedis();
+        return APIDataResponse.of("테스트 데이터가 Redis에 저장되었습니다.");
+    }
+
     /** 매칭 취소 */
     @DeleteMapping("/cancel")
     public APIDataResponse<?> cancelMatch(@CurrentMemberId Long memberId) {

--- a/src/main/java/com/tools/seoultech/timoproject/match/controller/MatchController.java
+++ b/src/main/java/com/tools/seoultech/timoproject/match/controller/MatchController.java
@@ -41,6 +41,13 @@ public class MatchController {
         return APIDataResponse.of("매칭이 취소되었습니다.");
     }
 
+    /** 모든 매칭 취소 */
+    @DeleteMapping("/cancelAll/{gameMode}")
+    public APIDataResponse<?> cancelAllMatch(@PathVariable String gameMode) {
+        matchingService.removeAllFromQueue(gameMode);
+        return APIDataResponse.of("모든 매칭이 취소되었습니다.");
+    }
+
     /** 매칭 수락 */
     @PostMapping("/accept/{matchId}")
     public APIDataResponse<?> acceptMatch(@CurrentMemberId Long memberId, @PathVariable String matchId) {

--- a/src/main/java/com/tools/seoultech/timoproject/match/service/MatchingService.java
+++ b/src/main/java/com/tools/seoultech/timoproject/match/service/MatchingService.java
@@ -18,6 +18,8 @@ public interface MatchingService {
 
     void removeAllFromQueue(String gameMode);
 
+    void saveTestDataToRedis();
+
     boolean acceptMatch(String matchId, Long memberId);
 
     boolean denyMatch(String matchId, Long memberId);

--- a/src/main/java/com/tools/seoultech/timoproject/match/service/MatchingService.java
+++ b/src/main/java/com/tools/seoultech/timoproject/match/service/MatchingService.java
@@ -16,6 +16,8 @@ public interface MatchingService {
 
     void removeFromQueue(Long memberId);
 
+    void removeAllFromQueue(String gameMode);
+
     boolean acceptMatch(String matchId, Long memberId);
 
     boolean denyMatch(String matchId, Long memberId);

--- a/src/main/java/com/tools/seoultech/timoproject/match/service/MatchingServiceImpl.java
+++ b/src/main/java/com/tools/seoultech/timoproject/match/service/MatchingServiceImpl.java
@@ -308,6 +308,25 @@ public class MatchingServiceImpl implements MatchingService {
         redisTemplate.delete(USER_INFO_PREFIX + memberId);
     }
 
+    /** 대기열에서 모든 유저 삭제 */
+    @Override
+    public void removeAllFromQueue(String gameMode) {
+        String queueKey = MATCHING_QUEUE_PREFIX + gameMode;
+
+        // 대기열에 있는 모든 유저 ID 가져오기
+        Set<String> allUserIds = zSetOps.range(queueKey, 0, -1);
+
+        // 대기열에서 모든 유저 삭제
+        if (allUserIds != null && !allUserIds.isEmpty()) {
+            for (String userId : allUserIds) {
+                zSetOps.remove(queueKey, userId);  // 대기열에서 유저만 삭제
+            }
+            log.info("대기열에서 모든 유저를 삭제했습니다. (게임 모드: {})", gameMode);
+        } else {
+            log.info("대기열이 비어 있습니다. (게임 모드: {})", gameMode);
+        }
+    }
+
     /** 거절당한 상대방 다시 매칭 진행 */
     private void requeueMember(Long memberId) {
         String userKey = USER_INFO_PREFIX + memberId;

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -6,7 +6,6 @@ TRUNCATE TABLE rating;
 TRUNCATE TABLE comment;
 TRUNCATE TABLE post;
 TRUNCATE TABLE member;
--- user_info, duo_info 테이블 관련 삭제
 
 -------------------------------------------------
 -- 1. MEMBER 테이블
@@ -61,6 +60,63 @@ INSERT INTO rating (score, attitude, speech, skill, member_id, duo_id)
 VALUES
     (4.5, 'GOOD', 'MANNERS', 'LEARNING', 1, 2),
     (2.5, 'BAD', 'AGGRESSIVE', 'NORMAL', 1, 2);
+
+-------------------------------------------------
+-- 5. MatchingOption  테이블
+-------------------------------------------------
+INSERT INTO user_info (user_info_id, introduce, game_mode, play_position, play_condition, voice_chat, play_style)
+VALUES
+    (1, '팀워크 중요111', 'RANK', 'RANGED_DEALER', 'FIRST', 'ENABLED', 'FUN'),
+    (2, '팀워크 중요222', 'RANK', 'SUPPORT', 'FIRST', 'ENABLED', 'FUN'),
+    (3, '팀워크 중요333', 'RANK', 'TOP', 'FIRST', 'ENABLED', 'FUN'),
+    (4, '팀워크 중요444', 'RANK', 'MID', 'FIRST', 'ENABLED', 'FUN'),
+    (5, '팀워크 중요555', 'RANK', 'SUPPORT', 'FIRST', 'ENABLED', 'HARDCORE'),
+    (6, '팀워크 중요666', 'RANK', 'SUPPORT', 'FIRST', 'DISABLED', 'HARDCORE'),
+    (7, '팀워크 중요777', 'RANK', 'SUPPORT', 'FIRST', 'ENABLED', 'HARDCORE'),
+    (8, '팀워크 중요888', 'RANK', 'SUPPORT', 'FIRST', 'ENABLED', 'HARDCORE');
+
+INSERT INTO duo_info (duo_info_id, duo_play_position, duo_play_style)
+VALUES
+    (1, 'SUPPORT', 'FUN'),
+    (2, 'RANGED_DEALER', 'FUN'),
+    (3, 'RANGED_DEALER', 'FUN'),
+    (4, 'JUNGLE', 'FUN'),
+    (5, 'RANGED_DEALER', 'FUN'),
+    (6, 'JUNGLE', 'FUN'),
+    (7, 'MID', 'FUN'),
+    (8, 'TOP', 'FUN');
+
+UPDATE member
+SET user_info_id = 1, duo_info_id = 1
+WHERE member_id = 1;
+
+UPDATE member
+SET user_info_id = 2, duo_info_id = 2
+WHERE member_id = 2;
+
+UPDATE member
+SET user_info_id = 3, duo_info_id = 3
+WHERE member_id = 3;
+
+UPDATE member
+SET user_info_id = 4, duo_info_id = 4
+WHERE member_id = 4;
+
+UPDATE member
+SET user_info_id = 5, duo_info_id = 5
+WHERE member_id = 5;
+
+UPDATE member
+SET user_info_id = 6, duo_info_id = 6
+WHERE member_id = 6;
+
+UPDATE member
+SET user_info_id = 7, duo_info_id = 7
+WHERE member_id = 7;
+
+UPDATE member
+SET user_info_id = 8, duo_info_id = 8
+WHERE member_id = 8;
 
 -- 외래키 체크 활성화
 SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
#️⃣연관된 이슈
ex) #이슈번호, #이슈번호
https://github.com/Timo-GG/timo-back-repository/issues/63

📝작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

1. 매칭 부가 점수 알고리즘 변경
<img width="832" alt="image" src="https://github.com/user-attachments/assets/dc995a15-bce4-4d84-b34e-eefc5c3b6866" />
기존 포지션 검사로는 매칭을 돌리는 사용자의 포지션만 고려하기 때문에
대기열에 있는 사용자가 원하는 듀오의 포지션은 고려 못함.
그래서 부가점수에 나의 포지션이 매칭된 사용자가 원하는 듀오의 포지션인지 확인하는 조건 추가.

2. data.sql 데이터 추가
<img width="822" alt="image" src="https://github.com/user-attachments/assets/377f6c5b-98a7-451c-ad8f-9ba475cc5f29" />

3. 테스트 데이터 Redis 대기열에 삽입하는 로직 추가
<img width="544" alt="image" src="https://github.com/user-attachments/assets/5f5d4aa5-068a-4682-a208-54feb52d520e" />

4. Redis 대기열의 모든 대기중인 사용자 제거하는 로직 추가
<img width="560" alt="image" src="https://github.com/user-attachments/assets/369f7bc8-88c7-483d-af7b-fc62be9f6cf6" />

5. 필수 조건(포지션) 필터링 후 점수 순으로 매칭하는지 확인하는 데이터 추가
<img width="1135" alt="image" src="https://github.com/user-attachments/assets/7540655c-e857-4c19-8929-654ddcacaf0b" />
Postman 상에서 테스트 데이터 삽입은 data.sql 상에서 memberId가 5,6,7,8 인 사용자를 대기열에 추가하고
그후에 memberId가 1인 사용자를 매칭 시작하면 가장 적합한 사용자를 매칭해주는 것으로 확인.

💬리뷰 요구사항(선택)
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
