### PR TITLE
[Feat] Policy 도메인 추가

### DIFF
--- a/src/main/java/com/tools/seoultech/timoproject/policy/Status.java
+++ b/src/main/java/com/tools/seoultech/timoproject/policy/Status.java
@@ -1,0 +1,5 @@
+package com.tools.seoultech.timoproject.policy;
+
+public enum Status {
+    ACTIVATED, EXPIRED
+}

--- a/src/main/java/com/tools/seoultech/timoproject/policy/controller/PolicyAPIController.java
+++ b/src/main/java/com/tools/seoultech/timoproject/policy/controller/PolicyAPIController.java
@@ -1,0 +1,41 @@
+package com.tools.seoultech.timoproject.policy.controller;
+
+import com.tools.seoultech.timoproject.global.APIErrorResponse;
+import com.tools.seoultech.timoproject.global.annotation.CurrentMemberId;
+import com.tools.seoultech.timoproject.global.constant.ErrorCode;
+import com.tools.seoultech.timoproject.policy.service.PolicyService;
+import com.tools.seoultech.timoproject.riot.dto.APIDataResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/policy")
+@RequiredArgsConstructor
+public class PolicyAPIController {
+    private final PolicyService policyService;
+    @GetMapping
+    public APIDataResponse create(@CurrentMemberId Long memberId){
+        policyService.save(memberId);
+        return APIDataResponse.empty();
+    }
+    @DeleteMapping
+    public APIDataResponse delete(@CurrentMemberId Long memberId){
+        policyService.delete(memberId);
+        return APIDataResponse.empty();
+    }
+    @GetMapping("/isExpired")
+    public APIDataResponse expiredCheck(@CurrentMemberId Long memberId){
+        return policyService.isExpired(memberId) ?
+                APIDataResponse.of(
+                        false,
+                        APIErrorResponse.of(
+                                false,
+                                ErrorCode.VALIDATION_ERROR,
+                                "만기되었습니다."
+                        )) :
+                APIDataResponse.empty();
+    }
+}

--- a/src/main/java/com/tools/seoultech/timoproject/policy/domain/dto/PolicyDto.java
+++ b/src/main/java/com/tools/seoultech/timoproject/policy/domain/dto/PolicyDto.java
@@ -1,0 +1,13 @@
+package com.tools.seoultech.timoproject.policy.domain.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public record PolicyDto(
+        Long policyId,
+        @NotNull Boolean usingAgreement,
+        @NotNull Boolean collectingAgreement,
+        LocalDateTime regDate,
+        LocalDateTime modDate
+) {
+}

--- a/src/main/java/com/tools/seoultech/timoproject/policy/domain/entity/Policy.java
+++ b/src/main/java/com/tools/seoultech/timoproject/policy/domain/entity/Policy.java
@@ -1,0 +1,29 @@
+package com.tools.seoultech.timoproject.policy.domain.entity;
+
+import com.tools.seoultech.timoproject.global.BaseEntity;
+import com.tools.seoultech.timoproject.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Policy extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="polish_id", nullable = false)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private Member member;
+
+    @Column(nullable = false)
+    private Boolean usingAgreement;  //  terms and conditions for
+
+    @Column(nullable = false)
+    private Boolean collectingAgreement;  // Consent to Collection and Use of Personal Information
+
+}

--- a/src/main/java/com/tools/seoultech/timoproject/policy/repository/PolicyRepository.java
+++ b/src/main/java/com/tools/seoultech/timoproject/policy/repository/PolicyRepository.java
@@ -1,0 +1,13 @@
+package com.tools.seoultech.timoproject.policy.repository;
+
+import com.tools.seoultech.timoproject.policy.domain.entity.Policy;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+
+@Repository
+public interface PolicyRepository extends JpaRepository<Policy, Long > {
+    void deleteByMemberId(Long memberId);
+    boolean existsByMemberIdAndRegDateBefore(Long memberId, LocalDateTime now);
+}

--- a/src/main/java/com/tools/seoultech/timoproject/policy/service/PolicyService.java
+++ b/src/main/java/com/tools/seoultech/timoproject/policy/service/PolicyService.java
@@ -1,0 +1,7 @@
+package com.tools.seoultech.timoproject.policy.service;
+
+public interface PolicyService {
+    void save(Long memberId);
+    void delete(Long memberId);
+    boolean isExpired(Long memberId);
+}

--- a/src/main/java/com/tools/seoultech/timoproject/policy/service/impl/PolicyServiceImpl.java
+++ b/src/main/java/com/tools/seoultech/timoproject/policy/service/impl/PolicyServiceImpl.java
@@ -1,0 +1,47 @@
+package com.tools.seoultech.timoproject.policy.service.impl;
+
+import com.tools.seoultech.timoproject.global.exception.GeneralException;
+import com.tools.seoultech.timoproject.member.domain.Member;
+import com.tools.seoultech.timoproject.member.repository.MemberRepository;
+import com.tools.seoultech.timoproject.policy.domain.entity.Policy;
+import com.tools.seoultech.timoproject.policy.repository.PolicyRepository;
+import com.tools.seoultech.timoproject.policy.service.PolicyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class PolicyServiceImpl implements PolicyService {
+    private final PolicyRepository policyRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public void save(Long memberId) {
+        Member member = memberRepository
+                .findById(memberId)
+                .orElseThrow(() -> new GeneralException("해당 사용자가 존재하지 않습니다."));
+        policyRepository.save(Policy.builder()
+                .member(member)
+                .usingAgreement(true)
+                .collectingAgreement(true)
+                .build()
+        );
+    }
+
+    @Override
+    public void delete(Long memberId) {
+        if(!memberRepository.existsById(memberId))
+            throw new GeneralException("해당 사용자가 존재하지 않습니다.");
+
+        policyRepository.deleteByMemberId(memberId);
+    }
+
+    @Override
+    public boolean isExpired(Long memberId) {
+        if(!memberRepository.existsById(memberId))
+            throw new GeneralException("해당하는 사용자가 존재하지 않습니다.");
+        return policyRepository.existsByMemberIdAndRegDateBefore(memberId, LocalDateTime.now().minusYears(5));
+    }
+}


### PR DESCRIPTION
#️⃣연관된 이슈
ex) #이슈번호, #이슈번호
#84 : [Feat]-#84-Terms-and-Conditions-for-Memberships

📝작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
1. Polish 엔티티
<img width="956" alt="image" src="https://github.com/user-attachments/assets/b5b3c4fb-05a1-4f50-b813-81e1b5abdaa8" />

2. 서비스 메서드 추가
<img width="1017" alt="image" src="https://github.com/user-attachments/assets/5b541a66-ed2a-40f4-940a-9a3919c1c6ec" />

3. 컨트롤러 추가
<img width="775" alt="image" src="https://github.com/user-attachments/assets/f5badb44-f810-429d-af25-924d2d51374d" />


💬리뷰 요구사항(선택)
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-  멤버 회원가입시 해당 레퍼지토리에 저장할 수 있도록, 백엔드에서 하는게 편할까? 아니면 프론트에서 요청하도록 API로만 기능 만들어둬야하냐?