### PR TITLE
Feat/#94 socket additional logic

### DIFF
--- a/src/main/java/com/tools/seoultech/timoproject/auth/service/OAuthLoginService.java
+++ b/src/main/java/com/tools/seoultech/timoproject/auth/service/OAuthLoginService.java
@@ -39,6 +39,7 @@ public class OAuthLoginService {
         Member member = Member.builder()
                 .email(oAuthInfoResponse.getEmail())
                 .nickname(memberService.randomCreateNickname())
+                .profileImageId(memberService.randomCreateProfileImageId())
                 .oAuthProvider(oAuthInfoResponse.getOAuthProvider())
                 .build();
 

--- a/src/main/java/com/tools/seoultech/timoproject/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/tools/seoultech/timoproject/chat/repository/ChatRoomMemberRepository.java
@@ -14,4 +14,6 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
     Optional<ChatRoomMember> findByChatRoomIdAndMemberId(Long chatRoomId, Long memberId);
 
     Collection<ChatRoomMember> findByChatRoomId(Long roomId);
+
+    List<ChatRoomMember> findByMemberId(Long memberId);
 }

--- a/src/main/java/com/tools/seoultech/timoproject/match/domain/DuoInfo.java
+++ b/src/main/java/com/tools/seoultech/timoproject/match/domain/DuoInfo.java
@@ -31,4 +31,9 @@ public class DuoInfo {
         this.duoPlayPosition = duoPlayPosition;
         this.duoPlayStyle = duoPlayStyle;
     }
+
+    public void update(PlayPosition duoPlayPosition, PlayStyle duoPlayStyle) {
+        this.duoPlayPosition = duoPlayPosition;
+        this.duoPlayStyle = duoPlayStyle;
+    }
 }

--- a/src/main/java/com/tools/seoultech/timoproject/match/domain/UserInfo.java
+++ b/src/main/java/com/tools/seoultech/timoproject/match/domain/UserInfo.java
@@ -47,4 +47,14 @@ public class UserInfo {
         this.voiceChat = voiceChat;
         this.playStyle = playStyle;
     }
+
+    public void update(String introduce, GameMode gameMode, PlayPosition playPosition,
+                       PlayCondition playCondition, VoiceChat voiceChat, PlayStyle playStyle) {
+        this.introduce = introduce;
+        this.gameMode = gameMode;
+        this.playPosition = playPosition;
+        this.playCondition = playCondition;
+        this.voiceChat = voiceChat;
+        this.playStyle = playStyle;
+    }
 }

--- a/src/main/java/com/tools/seoultech/timoproject/match/service/MatchingOptionServiceImpl.java
+++ b/src/main/java/com/tools/seoultech/timoproject/match/service/MatchingOptionServiceImpl.java
@@ -23,10 +23,10 @@ public class MatchingOptionServiceImpl implements MatchingOptionService {
     public MatchingOptionResponse updateMatchingOption(Long memberId, MatchingOptionRequest request) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("Member not found: " + memberId));
-        UserInfo userInfo = request.toUserInfo();
-        DuoInfo duoInfo = request.toDuoInfo();
-        member.updateMatchOption(userInfo, duoInfo);
-        memberRepository.flush();
+        UserInfo newUserInfo = request.toUserInfo();
+        DuoInfo newDuoInfo = request.toDuoInfo();
+        member.updateMatchOption(newUserInfo, newDuoInfo);
+
         return new MatchingOptionResponse(member);
     }
 

--- a/src/main/java/com/tools/seoultech/timoproject/match/service/MatchingOptionServiceImpl.java
+++ b/src/main/java/com/tools/seoultech/timoproject/match/service/MatchingOptionServiceImpl.java
@@ -23,15 +23,10 @@ public class MatchingOptionServiceImpl implements MatchingOptionService {
     public MatchingOptionResponse updateMatchingOption(Long memberId, MatchingOptionRequest request) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("Member not found: " + memberId));
-
-        // UserInfo 엔티티 생성
         UserInfo userInfo = request.toUserInfo();
-
-        // DuoInfo 엔티티 생성
         DuoInfo duoInfo = request.toDuoInfo();
-
-        // Member의 메칭 설정 업데이트
         member.updateMatchOption(userInfo, duoInfo);
+        memberRepository.flush();
         return new MatchingOptionResponse(member);
     }
 

--- a/src/main/java/com/tools/seoultech/timoproject/match/service/MatchingServiceImpl.java
+++ b/src/main/java/com/tools/seoultech/timoproject/match/service/MatchingServiceImpl.java
@@ -58,14 +58,13 @@ public class MatchingServiceImpl implements MatchingService {
         }
     }
 
+    @Transactional
     @Override
     public Optional<String> startMatch(Long memberId, MatchingOptionRequest request) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("Member not found : " + memberId));
-
         UserInfo userInfo = request.toUserInfo();
         DuoInfo duoInfo = request.toDuoInfo();
-
         member.updateMatchOption(userInfo, duoInfo);
         memberRepository.flush();
 

--- a/src/main/java/com/tools/seoultech/timoproject/member/domain/Member.java
+++ b/src/main/java/com/tools/seoultech/timoproject/member/domain/Member.java
@@ -84,9 +84,10 @@ public class Member extends BaseEntity {
     }
 
     @Builder
-    public Member(String email, String nickname, OAuthProvider oAuthProvider) {
+    public Member(String email, String nickname, Integer profileImageId, OAuthProvider oAuthProvider) {
         this.email = email;
         this.nickname = nickname;
+        this.profileImageId = profileImageId;
         this.oAuthProvider = oAuthProvider;
         this.role = Role.MEMBER;
     }

--- a/src/main/java/com/tools/seoultech/timoproject/member/domain/Member.java
+++ b/src/main/java/com/tools/seoultech/timoproject/member/domain/Member.java
@@ -62,9 +62,25 @@ public class Member extends BaseEntity {
     @JoinColumn(name = "duo_info_id")
     private DuoInfo duoInfo;
 
-    public void updateMatchOption(UserInfo userInfo, DuoInfo duoInfo) {
-        this.userInfo = userInfo;
-        this.duoInfo = duoInfo;
+    public void updateMatchOption(UserInfo newUserInfo, DuoInfo newDuoInfo) {
+        if (this.userInfo == null) this.userInfo = newUserInfo;
+        else {
+            this.userInfo.update(
+                    newUserInfo.getIntroduce(),
+                    newUserInfo.getGameMode(),
+                    newUserInfo.getPlayPosition(),
+                    newUserInfo.getPlayCondition(),
+                    newUserInfo.getVoiceChat(),
+                    newUserInfo.getPlayStyle()
+            );
+        }
+        if (this.duoInfo == null) this.duoInfo = newDuoInfo;
+        else {
+            this.duoInfo.update(
+                    newDuoInfo.getDuoPlayPosition(),
+                    newDuoInfo.getDuoPlayStyle()
+            );
+        }
     }
 
     @Builder

--- a/src/main/java/com/tools/seoultech/timoproject/member/service/MemberService.java
+++ b/src/main/java/com/tools/seoultech/timoproject/member/service/MemberService.java
@@ -11,6 +11,8 @@ public interface MemberService {
 
     String randomCreateNickname();
 
+    Integer randomCreateProfileImageId();
+
     Member updateAdditionalInfo(Long memberId, String nickname, String playerName, String playerTag);
 
     Integer updateProfileImageId(Long memberId, Integer imageId);

--- a/src/main/java/com/tools/seoultech/timoproject/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/tools/seoultech/timoproject/member/service/impl/MemberServiceImpl.java
@@ -32,6 +32,12 @@ public class MemberServiceImpl implements MemberService {
         return "티모대위" + "-" + UUID.randomUUID().toString().substring(0, 5);
     }
 
+    @Override
+    public Integer randomCreateProfileImageId() {
+        // 1~6 범위의 랜덤 숫자 생성
+        return (int) (Math.random() * 6) + 1;
+    }
+
     @Transactional
     public Member updateAdditionalInfo(Long memberId, String nickname, String playerName, String playerTag) {
         Member member = getById(memberId);

--- a/src/main/java/com/tools/seoultech/timoproject/rating/RatingController.java
+++ b/src/main/java/com/tools/seoultech/timoproject/rating/RatingController.java
@@ -1,6 +1,7 @@
 package com.tools.seoultech.timoproject.rating;
 
 import com.tools.seoultech.timoproject.global.annotation.CurrentMemberId;
+import com.tools.seoultech.timoproject.rating.dto.DuoResponse;
 import com.tools.seoultech.timoproject.rating.dto.RatingRequest;
 import com.tools.seoultech.timoproject.rating.dto.RatingResponse;
 import com.tools.seoultech.timoproject.rating.dto.RatingTotalResponse;
@@ -34,6 +35,12 @@ public class RatingController {
     public ResponseEntity<APIDataResponse<RatingTotalResponse>> getRatings(@CurrentMemberId Long memberId) {
         RatingTotalResponse rating = ratingService.getRatings(memberId);
         return ResponseEntity.ok(APIDataResponse.of(rating));
+    }
+
+    @GetMapping("/duos")
+    public ResponseEntity<APIDataResponse<List<DuoResponse>>> getMyDuoList(@CurrentMemberId Long memberId) {
+        List<DuoResponse> ratings = ratingService.getDuoList(memberId);
+        return ResponseEntity.ok(APIDataResponse.of(ratings));
     }
 
 }

--- a/src/main/java/com/tools/seoultech/timoproject/rating/RatingRepository.java
+++ b/src/main/java/com/tools/seoultech/timoproject/rating/RatingRepository.java
@@ -10,4 +10,6 @@ public interface RatingRepository extends JpaRepository<Rating, Long> {
     long countByMemberId(Long memberId);
 
     Optional<Rating> findByMemberIdAndDuoIdAndMatchId(Long memberId, Long duoId, String matchId);
+
+    boolean existsByMemberIdAndDuoIdAndMatchId(Long memberId, Long duoId, String matchId);
 }

--- a/src/main/java/com/tools/seoultech/timoproject/rating/RatingService.java
+++ b/src/main/java/com/tools/seoultech/timoproject/rating/RatingService.java
@@ -1,5 +1,6 @@
 package com.tools.seoultech.timoproject.rating;
 
+import com.tools.seoultech.timoproject.rating.dto.DuoResponse;
 import com.tools.seoultech.timoproject.rating.dto.RatingRequest;
 import com.tools.seoultech.timoproject.rating.dto.RatingResponse;
 import com.tools.seoultech.timoproject.rating.dto.RatingTotalResponse;
@@ -17,4 +18,7 @@ public interface RatingService {
 
         BigDecimal getRatingAverage(Long memberId);
 
+        boolean hasRated(Long memberId, Long duoId, String matchId);
+
+        List<DuoResponse> getDuoList(Long memberId);
 }

--- a/src/main/java/com/tools/seoultech/timoproject/rating/RatingServiceImpl.java
+++ b/src/main/java/com/tools/seoultech/timoproject/rating/RatingServiceImpl.java
@@ -1,11 +1,14 @@
 package com.tools.seoultech.timoproject.rating;
 
 import com.tools.seoultech.timoproject.chat.domain.ChatRoom;
+import com.tools.seoultech.timoproject.chat.domain.ChatRoomMember;
+import com.tools.seoultech.timoproject.chat.repository.ChatRoomMemberRepository;
 import com.tools.seoultech.timoproject.chat.repository.ChatRoomRepository;
 import com.tools.seoultech.timoproject.global.constant.ErrorCode;
 import com.tools.seoultech.timoproject.global.exception.BusinessException;
 import com.tools.seoultech.timoproject.member.domain.Member;
 import com.tools.seoultech.timoproject.member.repository.MemberRepository;
+import com.tools.seoultech.timoproject.rating.dto.DuoResponse;
 import com.tools.seoultech.timoproject.rating.dto.RatingRequest;
 import com.tools.seoultech.timoproject.rating.dto.RatingResponse;
 import com.tools.seoultech.timoproject.rating.dto.RatingTotalResponse;
@@ -15,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 @Service
@@ -25,6 +29,7 @@ public class RatingServiceImpl implements RatingService {
     private final RatingRepository ratingRepository;
     private final MemberRepository memberRepository;
     private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomMemberRepository chatRoomMemberRepository; // 가정
 
     @Override
     public RatingResponse saveRating(Long memberId, RatingRequest ratingRequest) {
@@ -78,6 +83,56 @@ public class RatingServiceImpl implements RatingService {
     public BigDecimal getRatingAverage(Long memberId) {
         List<Rating> ratings = ratingRepository.findByMemberId(memberId);
         return Rating.calculateAverageRatings(ratings);
+    }
+
+    @Override
+    public boolean hasRated(Long memberId, Long duoId, String matchId) {
+        return ratingRepository.existsByMemberIdAndDuoIdAndMatchId(memberId, duoId, matchId);
+    }
+
+    @Override
+    public List<DuoResponse> getDuoList(Long memberId) {
+        // (1) 해당 member가 참여했던 모든 ChatRoomMember 엔티티 조회
+        List<ChatRoomMember> myChatRoomMembers = chatRoomMemberRepository.findByMemberId(memberId);
+
+        // (2) 각 ChatRoomMember로부터 '같은 채팅방에 있는 다른 멤버(듀오)'를 찾아서
+        //     DuoListResponse를 만들어준다.
+        return myChatRoomMembers.stream()
+                .map(myCRM -> {
+                    ChatRoom chatRoom = myCRM.getChatRoom();
+                    String matchId = chatRoom.getMatchId();
+
+                    // 채팅방에 속한 전체 멤버들
+                    List<ChatRoomMember> allMembersInThisRoom = (List<ChatRoomMember>) chatRoomMemberRepository.findByChatRoomId(chatRoom.getId());
+                    // 나 자신(memberId)이 아닌 사람(=듀오)을 찾는다
+                    ChatRoomMember duoCRM = allMembersInThisRoom.stream()
+                            .filter(crm -> !crm.getMember().getId().equals(memberId))
+                            .findFirst()
+                            .orElse(null);
+                    // 1:1 채팅방 구조라면 .get()으로 가져와도 되지만, 널 체크는 습관적으로 해주는 편이 안전
+
+                    if (duoCRM == null) {
+                        throw new BusinessException(ErrorCode.NOT_FOUND_DUO_EXCEPTION);
+                    }
+
+                    Member duo = duoCRM.getMember();
+                    // (3) 이미 평점을 남겼는지 확인
+                    boolean isRated = hasRated(memberId, duo.getId(), matchId);
+
+                    // (4) DuoListResponse 생성
+                    return new DuoResponse(
+                            myCRM.getId(),         // 혹은 chatRoom.getId() 등 원하는 식별자
+                            duo.getId(),
+                            duo.getProfileImageId(), // 예시. 실제로는 duo의 프로필 필드에 맞춰서
+                            duo.getPlayerName(),   // 예시
+                            duo.getPlayerTag(),    // 예시
+                            matchId,
+                            isRated
+                    );
+                })
+                // null이 들어올 수도 있으니 필터링
+                .filter(Objects::nonNull)
+                .toList();
     }
 
     private RatingResponse mapToRatingResponse(Rating rating) {

--- a/src/main/java/com/tools/seoultech/timoproject/rating/dto/DuoResponse.java
+++ b/src/main/java/com/tools/seoultech/timoproject/rating/dto/DuoResponse.java
@@ -1,0 +1,12 @@
+package com.tools.seoultech.timoproject.rating.dto;
+
+public record DuoResponse(
+        Long id,
+        Long duoId,
+        int duoProfileImage,
+        String playerName,
+        String playerTag,
+        String matchId,
+        boolean isRated
+) {
+}

--- a/src/main/java/com/tools/seoultech/timoproject/socket/controller/MatchingSocketController.java
+++ b/src/main/java/com/tools/seoultech/timoproject/socket/controller/MatchingSocketController.java
@@ -6,6 +6,7 @@ import com.tools.seoultech.timoproject.match.dto.MatchNotificationDTO;
 import com.tools.seoultech.timoproject.match.dto.MatchResponseDTO;
 import com.tools.seoultech.timoproject.match.dto.MatchResult;
 import com.tools.seoultech.timoproject.match.dto.MatchingOptionRequest;
+import com.tools.seoultech.timoproject.match.service.MatchingOptionService;
 import com.tools.seoultech.timoproject.match.service.MatchingService;
 import com.tools.seoultech.timoproject.global.annotation.SocketController;
 import com.tools.seoultech.timoproject.global.annotation.SocketMapping;
@@ -20,11 +21,13 @@ import java.util.Set;
 public class MatchingSocketController {
 
     private final MatchingService matchingService;
+    private final MatchingOptionService matchingOptionService;
 
     @SocketMapping(endpoint = "match_start", requestCls = MatchingOptionRequest.class)
     public void handleStartMatch(SocketIOClient client, SocketIOServer server, MatchingOptionRequest request) {
         Long memberId = client.get("memberId");
         log.info("[match_start] memberId={}, request={}", memberId, request);
+        matchingOptionService.updateMatchingOption(memberId, request);
         var matchIdOpt = matchingService.startMatch(memberId, request);
         if (matchIdOpt.isPresent()) {
             String matchId = matchIdOpt.get();

--- a/src/main/java/com/tools/seoultech/timoproject/socket/controller/MatchingSocketController.java
+++ b/src/main/java/com/tools/seoultech/timoproject/socket/controller/MatchingSocketController.java
@@ -21,13 +21,11 @@ import java.util.Set;
 public class MatchingSocketController {
 
     private final MatchingService matchingService;
-    private final MatchingOptionService matchingOptionService;
 
     @SocketMapping(endpoint = "match_start", requestCls = MatchingOptionRequest.class)
     public void handleStartMatch(SocketIOClient client, SocketIOServer server, MatchingOptionRequest request) {
         Long memberId = client.get("memberId");
         log.info("[match_start] memberId={}, request={}", memberId, request);
-        matchingOptionService.updateMatchingOption(memberId, request);
         var matchIdOpt = matchingService.startMatch(memberId, request);
         if (matchIdOpt.isPresent()) {
             String matchId = matchIdOpt.get();

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -10,18 +10,18 @@ TRUNCATE TABLE member;
 -------------------------------------------------
 -- 1. MEMBER 테이블
 -------------------------------------------------
-INSERT INTO member (member_id, email, nickname, role, player_name, player_tag, reg_date, mod_date)
+INSERT INTO member (member_id, email, nickname, role, player_name, player_tag, profile_image_id, reg_date, mod_date)
 VALUES
-    (1,  'test1@example.com',  'hyunuk',    'MEMBER', 'Wooggie',       '#KR1',  NOW(), NOW()),
-    (2,  'test2@example.com',  'chanha',    'MEMBER', '롤찍먹만할게요', '#5103', NOW(), NOW()),
-    (3,  'test3@example.com',  'sangwoo',   'ADMIN',  '짱아깨비',      '#k r',  NOW(), NOW()),
-    (4,  'test4@example.com',  'pilho',     'MEMBER', '필호우스',      '#KR2',  NOW(), NOW()),
-    (5,  'test5@example.com',  'byeongjun', 'MEMBER', '병나발불어',    '#KR1',  NOW(), NOW()),
-    (6,  'test6@example.com',  'pilho',     'MEMBER', '필호우스',      '#KR2',  NOW(), NOW()),
-    (7,  'test7@example.com',  'kimjiwon',  'MEMBER', '도산안창호',     '#3402', NOW(), NOW()),
-    (8,  'test8@example.com',  'sangho',    'MEMBER', '백범김구',      '#HIGH', NOW(), NOW()),
-    (9,  'test9@example.com',  'youngjae',  'MEMBER', '행님',          '#KR1',  NOW(), NOW()),
-    (10, 'test10@example.com', 'yoonseok',  'MEMBER', '후아유',        '#9876', NOW(), NOW());
+    (1,  'test1@example.com',  'hyunuk',    'MEMBER', 'Wooggie',       '#KR1',  1, NOW(), NOW()),
+    (2,  'test2@example.com',  'chanha',    'MEMBER', '롤찍먹만할게요', '#5103', 2, NOW(), NOW()),
+    (3,  'test3@example.com',  'sangwoo',   'ADMIN',  '짱아깨비',      '#k r',  1, NOW(), NOW()),
+    (4,  'test4@example.com',  'pilho',     'MEMBER', '필호우스',      '#KR2',  2, NOW(), NOW()),
+    (5,  'test5@example.com',  'byeongjun', 'MEMBER', '병나발불어',    '#KR1',  1, NOW(), NOW()),
+    (6,  'test6@example.com',  'pilho',     'MEMBER', '필호우스',      '#KR2',  2, NOW(), NOW()),
+    (7,  'test7@example.com',  'kimjiwon',  'MEMBER', '도산안창호',     '#3402', 1, NOW(), NOW()),
+    (8,  'test8@example.com',  'sangho',    'MEMBER', '백범김구',      '#HIGH', 2, NOW(), NOW()),
+    (9,  'test9@example.com',  'youngjae',  'MEMBER', '행님',          '#KR1',  1, NOW(), NOW()),
+    (10, 'test10@example.com', 'yoonseok',  'MEMBER', '후아유',        '#9876', 2, NOW(), NOW());
 
 -------------------------------------------------
 -- 2. Post 테이블


### PR DESCRIPTION
한 것 
- Duo 리스트 조회 API 작성 
- matching_start시 matching_option 자동 생성
    - 만약 매칭 옵션 존재, 재활용 하도록 수정(update)(기존에는 user_info, duo_info 엔티티 자체를 주입하는거라 새로 만들어짐)
- data.sql에 profileImage 바꿈 
- randomProfileImageId 생성 (1~6 정수 범위)