### PR TITLE
[Feat] erd 연관관계 매핑: matching 간 user-board

### DIFF
--- a/src/main/java/com/tools/seoultech/timoproject/global/BaseEntity.java
+++ b/src/main/java/com/tools/seoultech/timoproject/global/BaseEntity.java
@@ -1,7 +1,10 @@
 package com.tools.seoultech.timoproject.global;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -10,6 +13,7 @@ import java.time.LocalDateTime;
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class BaseEntity {
     @CreatedDate

--- a/src/main/java/com/tools/seoultech/timoproject/match/domain/DuoInfo.java
+++ b/src/main/java/com/tools/seoultech/timoproject/match/domain/DuoInfo.java
@@ -1,5 +1,7 @@
 package com.tools.seoultech.timoproject.match.domain;
 
+import com.tools.seoultech.timoproject.version2.matching.user.entity.enumType.PlayPosition;
+import com.tools.seoultech.timoproject.version2.matching.user.entity.enumType.PlayStyle;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/src/main/java/com/tools/seoultech/timoproject/match/domain/PlayCondition.java
+++ b/src/main/java/com/tools/seoultech/timoproject/match/domain/PlayCondition.java
@@ -1,7 +1,0 @@
-package com.tools.seoultech.timoproject.match.domain;
-
-public enum PlayCondition {
-    FIRST,
-    CONTINUE,
-    LAST
-}

--- a/src/main/java/com/tools/seoultech/timoproject/match/domain/PlayStyle.java
+++ b/src/main/java/com/tools/seoultech/timoproject/match/domain/PlayStyle.java
@@ -1,6 +1,0 @@
-package com.tools.seoultech.timoproject.match.domain;
-
-public enum PlayStyle {
-    FUN,
-    HARDCORE,
-}

--- a/src/main/java/com/tools/seoultech/timoproject/match/domain/PlayUserInfo.java
+++ b/src/main/java/com/tools/seoultech/timoproject/match/domain/PlayUserInfo.java
@@ -1,0 +1,10 @@
+package com.tools.seoultech.timoproject.match.domain;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class PlayUserInfo {
+    private String puuid;
+    private String userName;
+    private String userTag;
+}

--- a/src/main/java/com/tools/seoultech/timoproject/match/domain/UserInfo.java
+++ b/src/main/java/com/tools/seoultech/timoproject/match/domain/UserInfo.java
@@ -1,5 +1,9 @@
 package com.tools.seoultech.timoproject.match.domain;
 
+import com.tools.seoultech.timoproject.version2.matching.user.entity.enumType.PlayCondition;
+import com.tools.seoultech.timoproject.version2.matching.user.entity.enumType.PlayPosition;
+import com.tools.seoultech.timoproject.version2.matching.user.entity.enumType.PlayStyle;
+import com.tools.seoultech.timoproject.version2.matching.user.entity.enumType.VoiceChat;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/src/main/java/com/tools/seoultech/timoproject/match/domain/VoiceChat.java
+++ b/src/main/java/com/tools/seoultech/timoproject/match/domain/VoiceChat.java
@@ -1,6 +1,0 @@
-package com.tools.seoultech.timoproject.match.domain;
-
-public enum VoiceChat {
-    ENABLED,
-    DISABLED,
-}

--- a/src/main/java/com/tools/seoultech/timoproject/match/dto/DuoInfoRequest.java
+++ b/src/main/java/com/tools/seoultech/timoproject/match/dto/DuoInfoRequest.java
@@ -1,6 +1,8 @@
 package com.tools.seoultech.timoproject.match.dto;
 
 import com.tools.seoultech.timoproject.match.domain.*;
+import com.tools.seoultech.timoproject.version2.matching.user.entity.enumType.PlayPosition;
+import com.tools.seoultech.timoproject.version2.matching.user.entity.enumType.PlayStyle;
 
 public record DuoInfoRequest(
         PlayPosition duoPlayPosition,

--- a/src/main/java/com/tools/seoultech/timoproject/post/domain/entity/Post.java
+++ b/src/main/java/com/tools/seoultech/timoproject/post/domain/entity/Post.java
@@ -5,6 +5,7 @@ import com.tools.seoultech.timoproject.member.domain.Member;
 import com.tools.seoultech.timoproject.post.domain.dto.PostDTO;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/tools/seoultech/timoproject/version2/matching/board/entity/BaseSearchBoard.java
+++ b/src/main/java/com/tools/seoultech/timoproject/version2/matching/board/entity/BaseSearchBoard.java
@@ -1,0 +1,34 @@
+package com.tools.seoultech.timoproject.version2.matching.board.entity;
+
+
+import com.tools.seoultech.timoproject.global.BaseEntity;
+import com.tools.seoultech.timoproject.version2.matching.user.entity.BaseUserEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class BaseSearchBoard extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "board_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private BaseUserEntity baseUser;
+
+    private String memo;
+
+    protected BaseSearchBoard(BaseUserEntity baseUser, String memo) {
+        this.baseUser = baseUser;
+        this.memo = memo;
+    }
+}

--- a/src/main/java/com/tools/seoultech/timoproject/version2/matching/board/entity/ColloseumSearchBoard.java
+++ b/src/main/java/com/tools/seoultech/timoproject/version2/matching/board/entity/ColloseumSearchBoard.java
@@ -1,0 +1,24 @@
+package com.tools.seoultech.timoproject.version2.matching.board.entity;
+
+
+import com.tools.seoultech.timoproject.version2.matching.user.entity.BaseUserEntity;
+import com.tools.seoultech.timoproject.version2.memberAccount.domain.entity.MemberAccount;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.PrimaryKeyJoinColumn;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@DiscriminatorValue("Duo-Type")
+@PrimaryKeyJoinColumn(name = "board_id")
+@Entity
+@NoArgsConstructor
+//@AllArgsConstructor
+@Getter
+public class ColloseumSearchBoard extends BaseSearchBoard{
+    @Builder
+    public ColloseumSearchBoard(BaseUserEntity baseUserEntity, String memo) {
+        super(baseUserEntity, memo);
+    }
+}

--- a/src/main/java/com/tools/seoultech/timoproject/version2/matching/board/entity/DuoSearchBoard.java
+++ b/src/main/java/com/tools/seoultech/timoproject/version2/matching/board/entity/DuoSearchBoard.java
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Getter
 public class DuoSearchBoard extends BaseSearchBoard{
     @Builder
-    public DuoSearchBoard(BaseUserEntity baseUserEntity, String memmo) {
-        super(baseUserEntity, memmo);
+    public DuoSearchBoard(BaseUserEntity baseUserEntity, String memo) {
+        super(baseUserEntity, memo);
     }
 }

--- a/src/main/java/com/tools/seoultech/timoproject/version2/matching/board/entity/DuoSearchBoard.java
+++ b/src/main/java/com/tools/seoultech/timoproject/version2/matching/board/entity/DuoSearchBoard.java
@@ -1,0 +1,23 @@
+package com.tools.seoultech.timoproject.version2.matching.board.entity;
+
+import com.tools.seoultech.timoproject.version2.matching.user.entity.BaseUserEntity;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.PrimaryKeyJoinColumn;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@DiscriminatorValue("Duo-Type")
+@PrimaryKeyJoinColumn(name = "board_id")
+@Entity
+@NoArgsConstructor
+//@AllArgsConstructor
+@Getter
+public class DuoSearchBoard extends BaseSearchBoard{
+    @Builder
+    public DuoSearchBoard(BaseUserEntity baseUserEntity, String memmo) {
+        super(baseUserEntity, memmo);
+    }
+}

--- a/src/main/java/com/tools/seoultech/timoproject/version2/matching/board/entity/enumType/boardCategory.java
+++ b/src/main/java/com/tools/seoultech/timoproject/version2/matching/board/entity/enumType/boardCategory.java
@@ -1,0 +1,6 @@
+package com.tools.seoultech.timoproject.version2.matching.board.entity.enumType;
+
+public enum boardCategory {
+    Duo,
+    Colosseum
+}

--- a/src/main/java/com/tools/seoultech/timoproject/version2/matching/myPage/entity/EnumType/MatchingCategory.java
+++ b/src/main/java/com/tools/seoultech/timoproject/version2/matching/myPage/entity/EnumType/MatchingCategory.java
@@ -1,0 +1,5 @@
+package com.tools.seoultech.timoproject.version2.matching.myPage.entity.EnumType;
+
+public enum MatchingCategory {
+    Duo_Type, Colosseum_Type
+}

--- a/src/main/java/com/tools/seoultech/timoproject/version2/matching/myPage/entity/EnumType/MatchingStatus.java
+++ b/src/main/java/com/tools/seoultech/timoproject/version2/matching/myPage/entity/EnumType/MatchingStatus.java
@@ -1,0 +1,5 @@
+package com.tools.seoultech.timoproject.version2.matching.myPage.entity.EnumType;
+
+public enum MatchingStatus {
+    WAITING, CONNECTED, DISCONNECTED, COMPLETED
+}

--- a/src/main/java/com/tools/seoultech/timoproject/version2/matching/myPage/entity/EnumType/OpponentAttitude.java
+++ b/src/main/java/com/tools/seoultech/timoproject/version2/matching/myPage/entity/EnumType/OpponentAttitude.java
@@ -1,0 +1,5 @@
+package com.tools.seoultech.timoproject.version2.matching.myPage.entity.EnumType;
+
+public enum OpponentAttitude {
+    BAD, POOR, AVERAGE, GOOD, EXCELLENT
+}

--- a/src/main/java/com/tools/seoultech/timoproject/version2/matching/myPage/entity/EnumType/OpponentConversation.java
+++ b/src/main/java/com/tools/seoultech/timoproject/version2/matching/myPage/entity/EnumType/OpponentConversation.java
@@ -1,0 +1,5 @@
+package com.tools.seoultech.timoproject.version2.matching.myPage.entity.EnumType;
+
+public enum OpponentConversation {
+    BAD, POOR, AVERAGE, GOOD, EXCELLENT
+}

--- a/src/main/java/com/tools/seoultech/timoproject/version2/matching/myPage/entity/EnumType/OpponentTalent.java
+++ b/src/main/java/com/tools/seoultech/timoproject/version2/matching/myPage/entity/EnumType/OpponentTalent.java
@@ -1,0 +1,5 @@
+package com.tools.seoultech.timoproject.version2.matching.myPage.entity.EnumType;
+
+public enum  OpponentTalent {
+    BAD, POOR, AVERAGE, GOOD, EXCELLENT
+}

--- a/src/main/java/com/tools/seoultech/timoproject/version2/matching/myPage/entity/MyPageBoard.java
+++ b/src/main/java/com/tools/seoultech/timoproject/version2/matching/myPage/entity/MyPageBoard.java
@@ -1,0 +1,29 @@
+package com.tools.seoultech.timoproject.version2.matching.myPage.entity;
+
+import com.tools.seoultech.timoproject.global.BaseEntity;
+import com.tools.seoultech.timoproject.version2.matching.user.entity.BaseUserEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MyPageBoard extends BaseEntity {
+    @Id
+    @GeneratedValue
+    @Column(name="myPage_id", nullable = false)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "requestor_id", nullable = false, updatable = false)
+    private BaseUserEntity requestor;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "acceptor_id", nullable = false, updatable = false)
+    private BaseUserEntity acceptor;
+}

--- a/src/main/java/com/tools/seoultech/timoproject/version2/matching/myPage/entity/Reivew.java
+++ b/src/main/java/com/tools/seoultech/timoproject/version2/matching/myPage/entity/Reivew.java
@@ -1,0 +1,44 @@
+package com.tools.seoultech.timoproject.version2.matching.myPage.entity;
+
+import com.tools.seoultech.timoproject.global.BaseEntity;
+import com.tools.seoultech.timoproject.version2.matching.myPage.entity.EnumType.OpponentAttitude;
+import com.tools.seoultech.timoproject.version2.matching.myPage.entity.EnumType.OpponentConversation;
+import com.tools.seoultech.timoproject.version2.matching.myPage.entity.EnumType.OpponentTalent;
+import com.tools.seoultech.timoproject.version2.memberAccount.domain.entity.MemberAccount;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Reivew extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "review_id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = {})
+    @JoinColumn(name = "member_id")
+    // TODO: 듀오 같은 경우, Timo.GG 사용자가 아닌 비회원 사용자면 어떻게 리뷰를 저장할건지?
+    private MemberAccount member;
+
+    @Column(nullable = false)
+    private OpponentAttitude attitude_score;
+
+    @Column(nullable = false)
+    private OpponentConversation conversation_score;
+
+    @Column(nullable = false)
+    private OpponentTalent talent_score;
+
+    @Column(nullable = false)
+    private Integer evaluation_score;
+
+    @Column(nullable = false)
+    private String memo;
+}

--- a/src/main/java/com/tools/seoultech/timoproject/version2/matching/user/entity/BaseUserEntity.java
+++ b/src/main/java/com/tools/seoultech/timoproject/version2/matching/user/entity/BaseUserEntity.java
@@ -21,7 +21,7 @@ public class BaseUserEntity {
     @Column(name = "user_id")
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name="member_id")
     private MemberAccount memberAccount;
 

--- a/src/main/java/com/tools/seoultech/timoproject/version2/matching/user/entity/BaseUserEntity.java
+++ b/src/main/java/com/tools/seoultech/timoproject/version2/matching/user/entity/BaseUserEntity.java
@@ -1,0 +1,31 @@
+package com.tools.seoultech.timoproject.version2.matching.user.entity;
+
+import com.tools.seoultech.timoproject.member.domain.Member;
+import com.tools.seoultech.timoproject.version2.memberAccount.domain.entity.MemberAccount;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class BaseUserEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "user_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name="member_id")
+    private MemberAccount memberAccount;
+
+    protected BaseUserEntity(MemberAccount memberAccount) {
+        this.memberAccount = memberAccount;
+    }
+}

--- a/src/main/java/com/tools/seoultech/timoproject/version2/matching/user/entity/ColosseumUserEntity.java
+++ b/src/main/java/com/tools/seoultech/timoproject/version2/matching/user/entity/ColosseumUserEntity.java
@@ -1,0 +1,32 @@
+package com.tools.seoultech.timoproject.version2.matching.user.entity;
+
+import com.tools.seoultech.timoproject.version2.matching.user.entity.embeddableType.PartyMemberInfo;
+import com.tools.seoultech.timoproject.version2.matching.user.entity.embeddableType.UserInfo_Ver2;
+import com.tools.seoultech.timoproject.version2.memberAccount.domain.entity.MemberAccount;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@DiscriminatorValue("Colosseum-Type")
+@PrimaryKeyJoinColumn(name = "user_id")
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class ColosseumUserEntity extends BaseUserEntity{
+    @ElementCollection
+    private List<PartyMemberInfo> partyMemberList;
+
+    @Builder
+    public ColosseumUserEntity(MemberAccount member, List<PartyMemberInfo> partyMemberList) {
+        super(member);
+        this.partyMemberList = partyMemberList;
+    }
+}

--- a/src/main/java/com/tools/seoultech/timoproject/version2/matching/user/entity/DuoUserEntity.java
+++ b/src/main/java/com/tools/seoultech/timoproject/version2/matching/user/entity/DuoUserEntity.java
@@ -1,0 +1,36 @@
+package com.tools.seoultech.timoproject.version2.matching.user.entity;
+
+import com.tools.seoultech.timoproject.version2.matching.user.entity.embeddableType.DuoInfo_Ver2;
+import com.tools.seoultech.timoproject.version2.matching.user.entity.embeddableType.UserInfo_Ver2;
+import com.tools.seoultech.timoproject.version2.memberAccount.domain.entity.MemberAccount;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.PrimaryKeyJoinColumn;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@DiscriminatorValue("Duo-Type")
+@PrimaryKeyJoinColumn(name = "user_id")
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class DuoUserEntity extends BaseUserEntity {
+    @Embedded
+    private UserInfo_Ver2 userInfo;
+
+    @Embedded
+    private DuoInfo_Ver2 duoInfo;
+
+    @Builder
+    public DuoUserEntity(MemberAccount member, UserInfo_Ver2 userInfo, DuoInfo_Ver2 duoInfo){
+        super(member);
+        this.userInfo = userInfo;
+        this.duoInfo = duoInfo;
+    }
+}

--- a/src/main/java/com/tools/seoultech/timoproject/version2/matching/user/entity/embeddableType/CompactPlayerHistory.java
+++ b/src/main/java/com/tools/seoultech/timoproject/version2/matching/user/entity/embeddableType/CompactPlayerHistory.java
@@ -1,0 +1,17 @@
+package com.tools.seoultech.timoproject.version2.matching.user.entity.embeddableType;
+
+import jakarta.persistence.Embeddable;
+
+import java.util.List;
+
+@Embeddable
+public class CompactPlayerHistory {
+    /*
+    * 해딩 필드 타입들은 RSO 정보 받아와야알 수 있음.
+    **/
+    private String rankTier;
+    private String tierStep;
+
+    private List<String> most3Champ;
+    private List<String> last4Match;
+}

--- a/src/main/java/com/tools/seoultech/timoproject/version2/matching/user/entity/embeddableType/DuoInfo_Ver2.java
+++ b/src/main/java/com/tools/seoultech/timoproject/version2/matching/user/entity/embeddableType/DuoInfo_Ver2.java
@@ -1,0 +1,11 @@
+package com.tools.seoultech.timoproject.version2.matching.user.entity.embeddableType;
+
+import com.tools.seoultech.timoproject.version2.matching.user.entity.enumType.PlayPosition;
+import com.tools.seoultech.timoproject.version2.matching.user.entity.enumType.PlayStyle;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class DuoInfo_Ver2 {
+    private PlayPosition opponentPosition;
+    private PlayStyle opponentStyle;
+}

--- a/src/main/java/com/tools/seoultech/timoproject/version2/matching/user/entity/embeddableType/PartyMemberInfo.java
+++ b/src/main/java/com/tools/seoultech/timoproject/version2/matching/user/entity/embeddableType/PartyMemberInfo.java
@@ -1,0 +1,18 @@
+package com.tools.seoultech.timoproject.version2.matching.user.entity.embeddableType;
+
+import com.tools.seoultech.timoproject.version2.memberAccount.domain.entity.RiotAccount;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+
+@Embeddable
+public class PartyMemberInfo {
+    @Embedded
+    private RiotAccount riotAccount;
+
+    @Embedded
+    private UserInfo_Ver2 userInfo;
+
+    // #TODO: Compact Riot 전적 조회
+    @Embedded
+    private CompactPlayerHistory compactPlayerHistory;
+}

--- a/src/main/java/com/tools/seoultech/timoproject/version2/matching/user/entity/embeddableType/UserInfo_Ver2.java
+++ b/src/main/java/com/tools/seoultech/timoproject/version2/matching/user/entity/embeddableType/UserInfo_Ver2.java
@@ -1,18 +1,15 @@
-package com.tools.seoultech.timoproject.match.dto;
+package com.tools.seoultech.timoproject.version2.matching.user.entity.embeddableType;
 
-import com.tools.seoultech.timoproject.match.domain.*;
 import com.tools.seoultech.timoproject.version2.matching.user.entity.enumType.PlayCondition;
 import com.tools.seoultech.timoproject.version2.matching.user.entity.enumType.PlayPosition;
 import com.tools.seoultech.timoproject.version2.matching.user.entity.enumType.PlayStyle;
 import com.tools.seoultech.timoproject.version2.matching.user.entity.enumType.VoiceChat;
+import jakarta.persistence.Embeddable;
 
-public record UserInfoRequest(
-        String introduce,
-        GameMode gameMode,
-        PlayPosition playPosition,
-        PlayCondition playCondition,
-        VoiceChat voiceChat,
-        PlayStyle playStyle
-) {
-
+@Embeddable
+public class UserInfo_Ver2 {
+    private PlayPosition myPosition;
+    private PlayStyle myStyle;
+    private PlayCondition myStatus;
+    private VoiceChat myVoice;
 }

--- a/src/main/java/com/tools/seoultech/timoproject/version2/matching/user/entity/enumType/PlayCondition.java
+++ b/src/main/java/com/tools/seoultech/timoproject/version2/matching/user/entity/enumType/PlayCondition.java
@@ -1,0 +1,7 @@
+package com.tools.seoultech.timoproject.version2.matching.user.entity.enumType;
+
+public enum PlayCondition {
+    FIRST,
+    CONTINUE,
+    LAST
+}

--- a/src/main/java/com/tools/seoultech/timoproject/version2/matching/user/entity/enumType/PlayPosition.java
+++ b/src/main/java/com/tools/seoultech/timoproject/version2/matching/user/entity/enumType/PlayPosition.java
@@ -1,4 +1,4 @@
-package com.tools.seoultech.timoproject.match.domain;
+package com.tools.seoultech.timoproject.version2.matching.user.entity.enumType;
 
 public enum PlayPosition {
     TOP,

--- a/src/main/java/com/tools/seoultech/timoproject/version2/matching/user/entity/enumType/PlayStyle.java
+++ b/src/main/java/com/tools/seoultech/timoproject/version2/matching/user/entity/enumType/PlayStyle.java
@@ -1,0 +1,7 @@
+package com.tools.seoultech.timoproject.version2.matching.user.entity.enumType;
+
+public enum PlayStyle {
+    NONE,
+    FUN,
+    HARDCORE,
+}

--- a/src/main/java/com/tools/seoultech/timoproject/version2/matching/user/entity/enumType/VoiceChat.java
+++ b/src/main/java/com/tools/seoultech/timoproject/version2/matching/user/entity/enumType/VoiceChat.java
@@ -1,0 +1,6 @@
+package com.tools.seoultech.timoproject.version2.matching.user.entity.enumType;
+
+public enum VoiceChat {
+    ENABLED,
+    DISABLED,
+}

--- a/src/main/java/com/tools/seoultech/timoproject/version2/memberAccount/domain/entity/CertifiedUnivInfo.java
+++ b/src/main/java/com/tools/seoultech/timoproject/version2/memberAccount/domain/entity/CertifiedUnivInfo.java
@@ -1,0 +1,15 @@
+package com.tools.seoultech.timoproject.version2.memberAccount.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.validation.constraints.Email;
+
+@Embeddable
+public class CertifiedUnivInfo {
+    @Email
+    @Column(nullable = false, unique = true)
+    private String univCertifiedEmail;
+
+    @Column(nullable = false)
+    private String department;
+}

--- a/src/main/java/com/tools/seoultech/timoproject/version2/memberAccount/domain/entity/MemberAccount.java
+++ b/src/main/java/com/tools/seoultech/timoproject/version2/memberAccount/domain/entity/MemberAccount.java
@@ -1,0 +1,27 @@
+package com.tools.seoultech.timoproject.version2.memberAccount.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberAccount {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "member_id")
+    private Long memberId;
+
+    @Column(nullable = false, unique = true)
+    private String userName;
+
+    @Embedded
+    private RiotAccount riotAccount;
+
+    @Embedded
+    private CertifiedUnivInfo certifiedUnivInfo;
+
+}

--- a/src/main/java/com/tools/seoultech/timoproject/version2/memberAccount/domain/entity/RiotAccount.java
+++ b/src/main/java/com/tools/seoultech/timoproject/version2/memberAccount/domain/entity/RiotAccount.java
@@ -1,0 +1,10 @@
+package com.tools.seoultech.timoproject.version2.memberAccount.domain.entity;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class RiotAccount {
+    private String puuid;
+    private String accountName;
+    private String accountTag;
+}


### PR DESCRIPTION
### 브랜치
---
- #119 

### 디렉토리 구조
---
- version2
     - matching
          - board
               1. BaseSearchBoard
               2. DuoSearchBoard
               3. ❎ ColosseumSearchBoard
          - user  
               1. BaseUserEntity
               2. DuoUserEntity
               3. ColosseumUserEntity
          - myPage
               1. ❎ MyPage

     - memberAccount
          1. MemberAccount 
          2. ❎  login-proccess