### PR TITLE
Feat/#145 notification

### DIFF
--- a/src/main/java/com/tools/seoultech/timoproject/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/tools/seoultech/timoproject/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -46,6 +46,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             new AntPathRequestMatcher("/api/v1/riot/recent-match"),
             new AntPathRequestMatcher("/api/v1/ranking/top"),
             new AntPathRequestMatcher("/api/v1/matching/**"),
+            new AntPathRequestMatcher("/api/v1/notifications/subscribe"),
             new AntPathRequestMatcher("/bower_components/**"),
             new AntPathRequestMatcher("/dist/**"),
             new AntPathRequestMatcher("/plugins/**"),

--- a/src/main/java/com/tools/seoultech/timoproject/global/config/SwaggerConfig.java
+++ b/src/main/java/com/tools/seoultech/timoproject/global/config/SwaggerConfig.java
@@ -58,7 +58,8 @@ public class SwaggerConfig {
                 "com.tools.seoultech.timoproject.matching.controller",
                 "com.tools.seoultech.timoproject.ranking",
                 "com.tools.seoultech.timoproject.auth",
-                "com.tools.seoultech.timoproject.riot"
+                "com.tools.seoultech.timoproject.riot",
+                "com.tools.seoultech.timoproject.notification",
 
         };
         return GroupedOpenApi.builder()

--- a/src/main/java/com/tools/seoultech/timoproject/notification/Notification.java
+++ b/src/main/java/com/tools/seoultech/timoproject/notification/Notification.java
@@ -1,0 +1,41 @@
+package com.tools.seoultech.timoproject.notification;
+
+import com.tools.seoultech.timoproject.memberAccount.domain.entity.MemberAccount;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class Notification {
+	@Id
+	@GeneratedValue(strategy = jakarta.persistence.GenerationType.IDENTITY)
+	private Long id;
+
+	@Enumerated(EnumType.STRING)
+	private NotificationType type;
+
+	private String redirectUrl;
+
+	private boolean isRead;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private MemberAccount memberAccount;
+
+	public void markAsRead() {
+		this.isRead = true;
+	}
+
+}

--- a/src/main/java/com/tools/seoultech/timoproject/notification/NotificationController.java
+++ b/src/main/java/com/tools/seoultech/timoproject/notification/NotificationController.java
@@ -1,0 +1,65 @@
+package com.tools.seoultech.timoproject.notification;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.tools.seoultech.timoproject.auth.jwt.JwtResolver;
+import com.tools.seoultech.timoproject.global.annotation.CurrentMemberId;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/notifications")
+@Tag(name = "Notification", description = "알림 API")
+public class NotificationController {
+
+	private final NotificationService notificationService;
+	private final JwtResolver jwtResolver;
+
+	/**
+	 * SSE 구독 (클라이언트가 알림 스트림 연결)
+	 * 토큰을 쿼리 파라미터로 받아서 memberId 추출
+	 */
+	@GetMapping(value = "/subscribe", produces = "text/event-stream")
+	public SseEmitter subscribe(@RequestParam String token) {
+		Long memberId = jwtResolver.getMemberIdFromAccessToken(token);
+		return notificationService.subscribe(memberId);
+	}
+
+	/**
+	 * 특정 사용자에게 알림 전송
+	 */
+	@PostMapping("/send")
+	public ResponseEntity<Void> sendNotification(@CurrentMemberId Long memberId,
+		@RequestBody NotificationRequest request) {
+		notificationService.sendNotification(memberId, request);
+		return ResponseEntity.ok().build();
+	}
+
+	/**
+	 * 특정 유저의 안 읽은 알림 조회
+	 */
+	@GetMapping("/unread")
+	public ResponseEntity<List<NotificationResponse>> getUnreadNotifications(@CurrentMemberId Long memberId) {
+		List<NotificationResponse> response = notificationService.getUnreadNotifications(memberId).stream()
+			.map(NotificationResponse::from)
+			.toList();
+
+		return ResponseEntity.ok(response);
+	}
+
+	/**
+	 * 특정 알림 읽음 처리
+	 */
+	@PostMapping("/{notificationId}/read")
+	public ResponseEntity<Void> markAsRead(@PathVariable Long notificationId) {
+		notificationService.markAsRead(notificationId);
+		return ResponseEntity.ok().build();
+	}
+}

--- a/src/main/java/com/tools/seoultech/timoproject/notification/NotificationRepository.java
+++ b/src/main/java/com/tools/seoultech/timoproject/notification/NotificationRepository.java
@@ -1,0 +1,12 @@
+package com.tools.seoultech.timoproject.notification;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.tools.seoultech.timoproject.memberAccount.domain.entity.MemberAccount;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+	List<Notification> findByMemberAccount(MemberAccount memberAccount);
+	List<Notification> findByMemberAccountAndIsReadFalse(MemberAccount memberAccount);
+}

--- a/src/main/java/com/tools/seoultech/timoproject/notification/NotificationRequest.java
+++ b/src/main/java/com/tools/seoultech/timoproject/notification/NotificationRequest.java
@@ -1,0 +1,6 @@
+package com.tools.seoultech.timoproject.notification;
+
+public record NotificationRequest(
+	NotificationType type,
+	String redirectUrl
+) {}

--- a/src/main/java/com/tools/seoultech/timoproject/notification/NotificationResponse.java
+++ b/src/main/java/com/tools/seoultech/timoproject/notification/NotificationResponse.java
@@ -1,0 +1,19 @@
+package com.tools.seoultech.timoproject.notification;
+
+public record NotificationResponse(
+	Long id,
+	NotificationType type,
+	String message,
+	String redirectUrl,
+	boolean isRead
+) {
+	public static NotificationResponse from(Notification notification) {
+		return new NotificationResponse(
+			notification.getId(),
+			notification.getType(),
+			notification.getType().getDefaultMessage(),
+			notification.getRedirectUrl(),
+			notification.isRead()
+		);
+	}
+}

--- a/src/main/java/com/tools/seoultech/timoproject/notification/NotificationService.java
+++ b/src/main/java/com/tools/seoultech/timoproject/notification/NotificationService.java
@@ -1,0 +1,74 @@
+package com.tools.seoultech.timoproject.notification;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.tools.seoultech.timoproject.memberAccount.domain.entity.MemberAccount;
+import com.tools.seoultech.timoproject.memberAccount.service.MemberAccountService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+	private final NotificationRepository notificationRepository;
+	private final MemberAccountService memberAccountService;
+
+	private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+	public SseEmitter subscribe(Long memberId) {
+		return setupEmitter(memberId);
+	}
+
+	public void sendNotification(Long memberId, NotificationRequest request) {
+		MemberAccount memberAccount = memberAccountService.getById(memberId);
+
+		Notification notification = Notification.builder()
+			.memberAccount(memberAccount)
+			.type(request.type())
+			.redirectUrl(request.redirectUrl())
+			.isRead(false)
+			.build();
+
+		notificationRepository.save(notification);
+
+		SseEmitter emitter = emitters.get(memberId);
+		if (emitter != null) {
+			try {
+				emitter.send(SseEmitter.event()
+					.name(notification.getType().name())  // 이벤트 이름: DUO_ACCEPTED 같은 enum 이름
+					.data(NotificationResponse.from(notification)));
+			} catch (IOException e) {
+				emitters.remove(memberId);
+			}
+		}
+	}
+
+	public List<Notification> getUnreadNotifications(Long memberId) {
+		MemberAccount memberAccount = memberAccountService.getById(memberId);
+		return notificationRepository.findByMemberAccountAndIsReadFalse(memberAccount);
+	}
+
+	public void markAsRead(Long notificationId) {
+		notificationRepository.findById(notificationId).ifPresent(notification -> {
+			notification.markAsRead();
+			notificationRepository.save(notification);
+		});
+	}
+
+	private SseEmitter setupEmitter(Long memberId) {
+		SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
+		emitters.put(memberId, emitter);
+		emitter.onCompletion(() -> emitters.remove(memberId));
+		emitter.onTimeout(() -> emitters.remove(memberId));
+		emitter.onError((e) -> emitters.remove(memberId));
+
+		return emitter;
+	}
+}

--- a/src/main/java/com/tools/seoultech/timoproject/notification/NotificationType.java
+++ b/src/main/java/com/tools/seoultech/timoproject/notification/NotificationType.java
@@ -1,0 +1,22 @@
+package com.tools.seoultech.timoproject.notification;
+
+public enum NotificationType {
+	RANKING_REGISTERED("랭킹 등록이 완료되었습니다."),
+	RANKING_UPDATED("랭킹이 업데이트되었습니다."),
+	COLOSSEUM_APPLY("콜로세움 신청이 접수되었습니다."),
+	COLOSSEUM_ACCEPTED("콜로세움 신청이 수락되었습니다."),
+	COLOSSEUM_REJECTED("콜로세움 신청이 거절되었습니다."),
+	DUO_APPLY("듀오 신청이 접수되었습니다."),
+	DUO_ACCEPTED("듀오 신청이 수락되었습니다."),
+	DUO_REJECTED("듀오 신청이 거절되었습니다.");
+
+	private final String defaultMessage;
+
+	NotificationType(String defaultMessage) {
+		this.defaultMessage = defaultMessage;
+	}
+
+	public String getDefaultMessage() {
+		return defaultMessage;
+	}
+}

--- a/src/main/java/com/tools/seoultech/timoproject/ranking/facade/RankingFacadeImpl.java
+++ b/src/main/java/com/tools/seoultech/timoproject/ranking/facade/RankingFacadeImpl.java
@@ -1,5 +1,8 @@
 package com.tools.seoultech.timoproject.ranking.facade;
 
+import com.tools.seoultech.timoproject.notification.NotificationRequest;
+import com.tools.seoultech.timoproject.notification.NotificationService;
+import com.tools.seoultech.timoproject.notification.NotificationType;
 import com.tools.seoultech.timoproject.riot.dto.RiotRankingDto;
 import com.tools.seoultech.timoproject.riot.facade.RiotFacade;
 import com.tools.seoultech.timoproject.ranking.dto.RankingUpdateRequestDto;
@@ -18,12 +21,15 @@ import java.util.List;
 public class RankingFacadeImpl implements RankingFacade {
     private final RankingService rankingService;
     private final RankingRedisService rankingRedisService;
+    private final NotificationService notificationService;
     private final RiotFacade riotFacade;
     
     @Override
     public void createRanking(Long memberId, String puuid) {
         RiotRankingDto riotRanking = riotFacade.getRiotRanking(puuid);
         rankingRedisService.createInitialRanking(memberId, riotRanking);
+        notificationService.sendNotification(memberId,
+            new NotificationRequest(NotificationType.RANKING_REGISTERED, "/ranking"));
     }
 
     @Override


### PR DESCRIPTION
* Notification 관련 로직 추가
* SSE (Server-Sent-Events) 방식 
<img width="259" alt="스크린샷 2025-05-06 오후 3 19 24" src="https://github.com/user-attachments/assets/db664872-8501-40e8-9450-1d2ac8f8ea71" />
<img width="674" alt="스크린샷 2025-05-06 오후 3 20 05" src="https://github.com/user-attachments/assets/029c77f7-453d-4d73-8310-d793e2d4fd80" />

* 여기서 Type과 message작성 가능 
<img width="757" alt="스크린샷 2025-05-06 오후 3 20 49" src="https://github.com/user-attachments/assets/0742ed0e-b127-4179-af85-ab82ca67b96c" />

* 활용 예시) 알림 넣을 곳에 sendNotification 이용하면 됩니다. 